### PR TITLE
Fix for CLI 0.2.0+

### DIFF
--- a/ComponentCSSPreprocessor.js
+++ b/ComponentCSSPreprocessor.js
@@ -13,13 +13,13 @@ function ComponentCssPreprocessor(options) {
 ComponentCssPreprocessor.prototype.toTree = function(tree, inputPath, outputPath) {
   // Filter out just the stylesheets in pods
   var filteredTree = new Funnel(tree, {
-    srcDir: this.options.podDir || 'app',
+    srcDir: this.options.addon.podDir() || 'app',
     exclude: [/^styles/]
   });
 
   // Process the tree from above, outputs pod-styles and pod-lookup
   var processedTree = new BrocComponentCssPreprocessor(filteredTree, {
-    pod: this.options.pod
+    pod: this.options.addon.pod
   });
 
   // Merge the processed tree into the original tree to add the `styles` dir back in

--- a/ComponentCssPostprocessor.js
+++ b/ComponentCssPostprocessor.js
@@ -17,7 +17,7 @@ ComponentCssPostprocessor.prototype = Object.create(Writer.prototype);
 ComponentCssPostprocessor.prototype.constructor = ComponentCssPostprocessor;
 
 ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
-  var pod = this.options.pod;
+  var pod = this.options.addon.pod;
 
   return readTree(this.inputTree).then(function(srcDir) {
     var paths = walkSync(srcDir);

--- a/package.json
+++ b/package.json
@@ -42,15 +42,18 @@
     "ember-addon"
   ],
   "ember-addon": {
-    "before": ["ember-cli-sass"],
+    "before": [
+      "ember-cli-sass"
+    ],
     "configPath": "tests/dummy/config"
   },
   "dependencies": {
-    "broccoli-writer": "^0.1.1",
-    "walk-sync": "^0.1.3",
     "broccoli-funnel": "^0.2.2",
-    "symlink-or-copy": "^1.0.1",
+    "broccoli-merge-trees": "^0.2.1",
+    "broccoli-writer": "^0.1.1",
     "css": "^2.2.0",
-    "broccoli-merge-trees": "^0.2.1"
+    "ember-cli-version-checker": "^1.0.2",
+    "symlink-or-copy": "^1.0.1",
+    "walk-sync": "^0.1.3"
   }
 }


### PR DESCRIPTION
I filed this against your PR instead of `master` to hopefully avoid merge conflicts :)

Tracked down the issue that was causing ebryn/ember-component-css#19 – the preprocessor was being registered in `included` rather than the `setupPreprocessorRegistry` hook that was added to support nested addons. Since `included` executes later, that meant we were always running _after_ other CSS preprocessors, and so just getting their output.

One note: I had to pass a reference to the addon instance into the preprocessor in order to calculate the pod directory lazily, because we don't have an `app` reference yet when `setupPreprocessorRegistry` is called.
Since I had to do that anyway, I also moved `pod` to be an instance variable on the addon. I suspect we're actually going to see style leakage across rebuilds because of the long-lived nature of that `pods` object, but at least this way it's scoped to individual instances of the addon.

Seem reasonable?
